### PR TITLE
Add scaling similar to logical render size in SDL

### DIFF
--- a/main.c
+++ b/main.c
@@ -171,14 +171,17 @@ int main(int argc, char **argv)
                     }
                 } break;
 
+                case SDLK_KP_PLUS:
                 case SDLK_EQUALS: {
                     user_scale += SCALE_FACTOR * user_scale;
                 } break;
 
+                case SDLK_KP_MINUS:
                 case SDLK_MINUS: {
                     user_scale -= SCALE_FACTOR * user_scale;
                 } break;
 
+                case SDLK_KP_0:
                 case SDLK_0: {
                     user_scale = 1.0f;
                 } break;

--- a/main.c
+++ b/main.c
@@ -6,15 +6,15 @@
 #define STB_IMAGE_IMPLEMENTATION
 #include "stb_image.h"
 
-#define SCREEN_WIDTH 800
-#define SCREEN_HEIGHT 600
 #define FPS 60
 #define DELTA_TIME (1.0f / FPS)
 #define SPRITE_DIGIT_WIDTH (300 / 2)
 #define SPRITE_DIGIT_HEIGHT (380 / 2)
 #define DIGIT_WIDTH (300 / 2)
 #define DIGIT_HEIGHT (380 / 2)
-#define DIGITS_COUNT 11
+#define DIGITS_COUNT 8
+#define TEXT_WIDTH (DIGIT_WIDTH * DIGITS_COUNT)
+#define TEXT_HEIGHT (DIGIT_HEIGHT)
 #define WIGGLE_COUNT 3
 #define WIGGLE_DURATION (0.40 / WIGGLE_COUNT)
 #define COLON_INDEX 10
@@ -106,7 +106,7 @@ void initial_pen(SDL_Window *window, int *pen_x, int *pen_y, float scale)
 
     const int effective_digit_width = (int) floorf((float) DIGIT_WIDTH * scale);
     const int effective_digit_height = (int) floorf((float) DIGIT_HEIGHT * scale);
-    *pen_x = w / 2 - effective_digit_width * 8 / 2;
+    *pen_x = w / 2 - effective_digit_width * DIGITS_COUNT / 2;
     *pen_y = h / 2 - effective_digit_height / 2;
 }
 
@@ -125,7 +125,7 @@ int main(int argc, char **argv)
     SDL_Window *window =
         secp(SDL_CreateWindow(
                  "sowon",
-                 0, 0, SCREEN_WIDTH, SCREEN_HEIGHT,
+                 0, 0, TEXT_WIDTH, TEXT_HEIGHT,
                  SDL_WINDOW_RESIZABLE));
 
     SDL_Renderer *renderer =

--- a/main.c
+++ b/main.c
@@ -189,15 +189,14 @@ int main(int argc, char **argv)
             } break;
 
             case SDL_MOUSEWHEEL: {
-                if(event.wheel.y > 0)
-                {
-                    user_scale += SCALE_FACTOR * user_scale;
+                if (SDL_GetModState() & KMOD_CTRL) {
+                    if (event.wheel.y > 0) {
+                        user_scale += SCALE_FACTOR * user_scale;
+                    } else if (event.wheel.y < 0) {
+                        user_scale -= SCALE_FACTOR * user_scale;
+                    }
                 }
-                else if(event.wheel.y < 0)
-                {
-                    user_scale -= SCALE_FACTOR * user_scale;
-                }
-            }
+            } break;
 
             default: {}
             }

--- a/main.c
+++ b/main.c
@@ -188,6 +188,17 @@ int main(int argc, char **argv)
                 }
             } break;
 
+            case SDL_MOUSEWHEEL: {
+                if(event.wheel.y > 0)
+                {
+                    user_scale += SCALE_FACTOR * user_scale;
+                }
+                else if(event.wheel.y < 0)
+                {
+                    user_scale -= SCALE_FACTOR * user_scale;
+                }
+            }
+
             default: {}
             }
         }

--- a/main.c
+++ b/main.c
@@ -8,13 +8,13 @@
 
 #define FPS 60
 #define DELTA_TIME (1.0f / FPS)
-#define SPRITE_DIGIT_WIDTH (300 / 2)
-#define SPRITE_DIGIT_HEIGHT (380 / 2)
-#define DIGIT_WIDTH (300 / 2)
-#define DIGIT_HEIGHT (380 / 2)
-#define DIGITS_COUNT 8
-#define TEXT_WIDTH (DIGIT_WIDTH * DIGITS_COUNT)
-#define TEXT_HEIGHT (DIGIT_HEIGHT)
+#define SPRITE_CHAR_WIDTH (300 / 2)
+#define SPRITE_CHAR_HEIGHT (380 / 2)
+#define CHAR_WIDTH (300 / 2)
+#define CHAR_HEIGHT (380 / 2)
+#define CHARS_COUNT 8
+#define TEXT_WIDTH (CHAR_WIDTH * CHARS_COUNT)
+#define TEXT_HEIGHT (CHAR_HEIGHT)
 #define WIGGLE_COUNT 3
 #define WIGGLE_DURATION (0.40 / WIGGLE_COUNT)
 #define COLON_INDEX 10
@@ -80,14 +80,14 @@ SDL_Texture *load_png_file_as_texture(SDL_Renderer *renderer,
 void render_digit_at(SDL_Renderer *renderer, SDL_Texture *digits, size_t digit_index,
                      size_t wiggle_index, int *pen_x, int *pen_y, float user_scale, float fit_scale)
 {
-    const int effective_digit_width = (int) floorf((float) DIGIT_WIDTH * user_scale * fit_scale);
-    const int effective_digit_height = (int) floorf((float) DIGIT_HEIGHT * user_scale * fit_scale);
+    const int effective_digit_width = (int) floorf((float) CHAR_WIDTH * user_scale * fit_scale);
+    const int effective_digit_height = (int) floorf((float) CHAR_HEIGHT * user_scale * fit_scale);
 
     const SDL_Rect src_rect = {
-        (int) (digit_index * SPRITE_DIGIT_WIDTH),
-        (int) (wiggle_index * SPRITE_DIGIT_HEIGHT),
-        SPRITE_DIGIT_WIDTH,
-        SPRITE_DIGIT_HEIGHT
+        (int) (digit_index * SPRITE_CHAR_WIDTH),
+        (int) (wiggle_index * SPRITE_CHAR_HEIGHT),
+        SPRITE_CHAR_WIDTH,
+        SPRITE_CHAR_HEIGHT
     };
     const SDL_Rect dst_rect = {
         *pen_x,
@@ -112,9 +112,9 @@ void initial_pen(SDL_Window *window, int *pen_x, int *pen_y, float user_scale, f
         *fit_scale = (float) h / (float) TEXT_HEIGHT;
     }
 
-    const int effective_digit_width = (int) floorf((float) DIGIT_WIDTH * user_scale * *fit_scale);
-    const int effective_digit_height = (int) floorf((float) DIGIT_HEIGHT * user_scale * *fit_scale);
-    *pen_x = w / 2 - effective_digit_width * DIGITS_COUNT / 2;
+    const int effective_digit_width = (int) floorf((float) CHAR_WIDTH * user_scale * *fit_scale);
+    const int effective_digit_height = (int) floorf((float) CHAR_HEIGHT * user_scale * *fit_scale);
+    *pen_x = w / 2 - effective_digit_width * CHARS_COUNT / 2;
     *pen_y = h / 2 - effective_digit_height / 2;
 }
 


### PR DESCRIPTION
- Refactored macros usage
- Added automatic scaling to always fit digits. As a side effect, user-defined zoom is now not absolute, but relative to the window.
- Added support for numpad keys and mouse wheel for zoom.