### PR TITLE
Add FreeBSD CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,3 +53,17 @@ jobs:
       - name: build sowon
         run: |
           ./build_msvc.bat
+  build-freebsd:
+    runs-on: macos-latest
+    name: FreeBSD LLVM Clang build
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build on FreeBSD
+      id: build
+      uses: vmactions/freebsd-vm@v0.0.9
+      with:
+        usesh: true
+        prepare: pkg install -y sdl2 pkgconf
+        run: |
+          freebsd-version
+          make


### PR DESCRIPTION
As discussed on Discord, this is an "example FreeBSD CI build."

Notes for some other projects:
+ GNU Make must be installed as an additional dependency
+ Same applies for pkg-config, autotools and bash (Generally all GNU Tools)

(I don't want a t-shirt plz)