### PR TITLE
Fix Windows CI errors not failing the build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,13 +58,13 @@ jobs:
     runs-on: macos-latest
     name: FreeBSD LLVM Clang build
     steps:
-    - uses: actions/checkout@v2
-    - name: Build on FreeBSD
-      id: build
-      uses: vmactions/freebsd-vm@v0.0.9
-      with:
-        usesh: true
-        prepare: pkg install -y sdl2 pkgconf
-        run: |
-          freebsd-version
-          make
+      - uses: actions/checkout@v2
+      - name: Build on FreeBSD
+        id: build
+        uses: vmactions/freebsd-vm@v0.0.9
+        with:
+          usesh: true
+          prepare: pkg install -y sdl2 pkgconf
+          run: |
+            freebsd-version
+            make

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
           tar -xf SDL2-devel-2.0.12-VC.zip
           mv SDL2-2.0.12 SDL2
       - name: build sowon
+        shell: cmd
         run: |
           ./build_msvc.bat
   build-freebsd:

--- a/build_msvc.bat
+++ b/build_msvc.bat
@@ -1,5 +1,5 @@
 @echo off
-rem launch this from msvs-enabled console
+rem launch this from msvc-enabled console
 
 set CXXFLAGS=/std:c++17 /O2 /FC /W4 /WX /nologo
 set INCLUDES=/I SDL2\include


### PR DESCRIPTION
Ported CI fix from Something which replaces default PowerShell to cmd.

Also fixed typo and formatting inconsistency.