### PR TITLE
Manual page and both install and clean target.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,12 @@
-COMMON_CFLAGS=-Wall -Wextra -std=c99 -pedantic
-CFLAGS=`pkg-config --cflags sdl2` $(COMMON_CFLAGS)
-COMMON_LIBS=-lm
-LIBS=`pkg-config --libs sdl2` $(COMMON_LIBS)
+COMMON_CFLAGS=		-Wall -Wextra -std=c99 -pedantic
+CFLAGS+=		`pkg-config --cflags sdl2` $(COMMON_CFLAGS)
+COMMON_LIBS=		-lm
+LIBS=			`pkg-config --libs sdl2` $(COMMON_LIBS)
+PREFIX?=		/usr/local/
+INSTALL?=		install
+
+.PHONY: all
+all: Makefile sowon man
 
 sowon: main.c digits.h
 	$(CC) $(CFLAGS) -o sowon main.c $(LIBS)
@@ -11,3 +16,20 @@ digits.h: png2c digits.png
 
 png2c: png2c.c
 	$(CC) $(COMMON_CFLAGS) -o png2c png2c.c -lm
+
+docs/sowon.6.gz: docs/sowon.6
+	gzip -c docs/sowon.6 > docs/sowon.6.gz
+
+.PHONY: man
+man: docs/sowon.6.gz
+
+.PHONY: clean
+clean:
+	rm sowon docs/sowon.6.gz png2c
+
+.PHONY: install
+install: all
+	$(INSTALL) -d $(DESTDIR)/$(PREFIX)/bin
+	$(INSTALL) -C ./sowon $(DESTDIR)/$(PREFIX)/bin
+	$(INSTALL) -d $(DESTDIR)/$(PREFIX)/man/man6
+	$(INSTALL) -C docs/sowon.6.gz $(DESTDIR)/$(PREFIX)/man/man6

--- a/docs/sowon.6
+++ b/docs/sowon.6
@@ -1,0 +1,41 @@
+.Dd November 29, 2020
+.Dt SOWON 6
+.Os AUXILIARY
+.Sh NAME
+.Nm sowon
+.Nd Starting soon timer
+.Sh SYNOPSIS
+.Nm
+.Op Fl p
+.Op Ar seconds | Ar clock
+.Sh DESCRIPTION
+.Nm
+is a graphical countdown/timer program.
+With no arguments provided, it starts in ascending mode. With an amount of
+seconds provided, it starts in descending mode. Clock starts it in clock
+mode, that displays the current time.
+.br
+.Sh OPTIONS
+.Bl -tag -width indent
+.It Fl p
+start in paused state
+.Sh KEY BINDINGS
+.Bl -tag -width indent
+.It SPACE
+Toggle pause
+.It =
+Zoom in
+.It -
+Zoom out
+.It 0
+Zoom 100%
+.Sh FILES
+.Pa /usr/local/bin/sowon
+.br
+.Sh AUTHOR
+.An Alexey Kutepov aka. rexim
+.Aq reximkut AT gmail DOT com
+.br
+.An Source code and issue tracker at
+.Aq https://github.com/tsoding/sowon
+.P


### PR DESCRIPTION
Also, I cleaned up the Makefile a bit to accomodate for portability requirements.
This includes e.g. not assigning to CFLAGS but appending to it. Otherwise the CFLAGS in the environment will be overwritten and in some cases this may cause compilation failures because architecture specific flags are necessary in order to produce valid executables.

In case this will be merged, I'm gonna write a FreeBSD ports Makefile.
For that it might be useful to have an official version number for sowon.