### PR TITLE
Add ability to quit application by pressing ctrl-q

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,4 @@ $ make
 | <kbd>0</kbd> | Zoom 100% |
 | <kbd>F5</kbd> | Restart |
 | <kbd>F11</kbd> | Fullscreen |
+| <kbd>CTRL+Q</kbd> | Quit |

--- a/main.c
+++ b/main.c
@@ -254,6 +254,14 @@ int main(int argc, char **argv)
                         secc(SDL_SetWindowFullscreen(window, SDL_WINDOW_FULLSCREEN_DESKTOP));
                     }
                 } break;
+
+                /* Quit application after pressing CTRL+Q */
+                case SDLK_q: {
+                    if (event.key.keysym.mod & KMOD_CTRL){
+                        quit = 1;
+                    }
+                } break;
+
                 }
             } break;
 


### PR DESCRIPTION
Now, to exit sowon, one has to find its PID in process list and type "kill" command in terminal. It's very uncomfortable. It would be nice to have CTRL+Q shortcut for closing this program.