### PR TITLE
address deprecation warning

### DIFF
--- a/main.c
+++ b/main.c
@@ -50,7 +50,7 @@ void *secp(void *ptr)
     return ptr;
 }
 
-SDL_Surface *load_png_file_as_surface()
+SDL_Surface *load_png_file_as_surface(void)
 {
     SDL_Surface* image_surface =
         secp(SDL_CreateRGBSurfaceFrom(


### PR DESCRIPTION
```
main.c:53:38: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
SDL_Surface *load_png_file_as_surface()
                                     ^
                                      void
1 warning generated.
```