### PR TITLE
Add escape key to quit

### DIFF
--- a/main.c
+++ b/main.c
@@ -248,6 +248,9 @@ int main(int argc, char **argv)
 
             case SDL_KEYDOWN: {
                 switch (event.key.keysym.sym) {
+                case SDLK_ESCAPE: {
+                    quit = 1;
+                } break;
                 case SDLK_SPACE: {
                     paused = !paused;
                     if (paused) {


### PR DESCRIPTION
Just like as in the [tsoding/boomer tool](https://github.com/tsoding/boomer) a hit on the escape key will now close `sowon`.

Earlier behavior, had to do mod+Shift+q in [i3-wm](https://i3wm.org/) to quit the app.