### PR TITLE
Let ascending timer display zero seconds

### DIFF
--- a/main.c
+++ b/main.c
@@ -189,7 +189,7 @@ void frame_end(FpsDeltaTime *fpsdt)
 int main(int argc, char **argv)
 {
     Mode mode = MODE_ASCENDING;
-    float displayed_time = 0.0f;
+    float displayed_time = -1.0f;
     int paused = 0;
     int exit_after_countdown = 0;
 
@@ -273,7 +273,7 @@ int main(int argc, char **argv)
                 } break;
 
                 case SDLK_F5: {
-                    displayed_time = 0.0f;
+                    displayed_time = -1.0f;
                     paused = 0;
                     for (int i = 1; i < argc; ++i) {
                         if (strcmp(argv[i], "-p") == 0) {


### PR DESCRIPTION
I noticed that although `displayed_time` is initially set to zero, the timer shows 00:00:00 only for a split second before jumping to 00:00:01. Setting `displayed_time = -1.0f;` will ensure that 00:00:00 is shown for exactly a second before continuing.

P.S.: Setting `displayed_time` to a negative value is probably not the prettiest solution, so please let me know if you think of a better one!