### PR TITLE
Fix CI and Windows build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: build sowon
         run: |
           if [ ${{ matrix.penger }} = true ]; then
-            make CFLAGS="-DPENGER"
+            make PENGER=1
           else
             make
           fi
@@ -35,7 +35,7 @@ jobs:
       - name: build sowon
         run: |
           if [ ${{ matrix.penger }} = true ]; then
-            make CFLAGS="-DPENGER"
+            make PENGER=1
           else
             make
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 
 jobs:
   build-linux-gcc:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
       - name: install dependencies
@@ -16,7 +16,7 @@ jobs:
         env:
           CC: gcc
   build-linux-clang:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
       - name: install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         compiler: [gcc, clang]
-        penger: [false, true]
+        penger: ["", "PENGER=1"]
     steps:
       - uses: actions/checkout@v1
       - name: install dependencies
@@ -16,36 +16,28 @@ jobs:
           sudo apt-get install -qq libsdl2-dev
       - name: build sowon
         run: |
-          if [ ${{ matrix.penger }} = true ]; then
-            make PENGER=1
-          else
-            make
-          fi
+          make ${{ matrix.penger }}
         env:
           CC: ${{ matrix.compiler }}
   build-macos:
     runs-on: macOS-latest
     strategy:
       matrix:
-        penger: [false, true]
+        penger: ["", "PENGER=1"]
     steps:
       - uses: actions/checkout@v1
       - name: install dependencies
         run: brew install sdl2 pkg-config
       - name: build sowon
         run: |
-          if [ ${{ matrix.penger }} = true ]; then
-            make PENGER=1
-          else
-            make
-          fi
+          make ${{ matrix.penger }}
         env:
           CC: clang
   build-windows-msvc:
     runs-on: windows-latest
     strategy:
       matrix:
-        penger: [false, true]
+        penger: ["", "PENGER"]
     steps:
       - uses: actions/checkout@v1
         # this runs vcvarsall for us, so we get the MSVC toolchain in PATH.
@@ -58,11 +50,7 @@ jobs:
       - name: build sowon
         shell: cmd
         run: |
-          if ${{ matrix.penger }} == true (
-            build_msvc.bat PENGER
-          ) else (
-            build_msvc.bat
-          )
+          build_msvc.bat ${{ matrix.penger }}
 # TODO: FreeBSD build is broken
 #  build-freebsd:
 #    runs-on: macos-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,10 @@ jobs:
         env:
           CC: clang
   build-windows-msvc:
-    runs-on: windows-2019
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        penger: [false, true]
     steps:
       - uses: actions/checkout@v1
         # this runs vcvarsall for us, so we get the MSVC toolchain in PATH.
@@ -55,7 +58,11 @@ jobs:
       - name: build sowon
         shell: cmd
         run: |
-          ./build_msvc.bat
+          if ${{ matrix.penger }} == true (
+            build_msvc.bat PENGER
+          ) else (
+            build_msvc.bat
+          )
 # TODO: FreeBSD build is broken
 #  build-freebsd:
 #    runs-on: macos-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,12 @@ name: CI
 on: [push, pull_request]
 
 jobs:
-  build-linux-gcc:
+  build-linux:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        compiler: [gcc, clang]
+        penger: [false, true]
     steps:
       - uses: actions/checkout@v1
       - name: install dependencies
@@ -12,31 +16,29 @@ jobs:
           sudo apt-get install -qq libsdl2-dev
       - name: build sowon
         run: |
-          make
+          if [ ${{ matrix.penger }} = true ]; then
+            make CFLAGS="-DPENGER"
+          else
+            make
+          fi
         env:
-          CC: gcc
-  build-linux-clang:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - name: install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -qq libsdl2-dev
-      - name: build sowon
-        run: |
-          make
-        env:
-          CC: clang
+          CC: ${{ matrix.compiler }}
   build-macos:
     runs-on: macOS-latest
+    strategy:
+      matrix:
+        penger: [false, true]
     steps:
       - uses: actions/checkout@v1
       - name: install dependencies
         run: brew install sdl2 pkg-config
       - name: build sowon
         run: |
-          make
+          if [ ${{ matrix.penger }} = true ]; then
+            make CFLAGS="-DPENGER"
+          else
+            make
+          fi
         env:
           CC: clang
   build-windows-msvc:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,18 +51,21 @@ jobs:
         shell: cmd
         run: |
           build_msvc.bat ${{ matrix.penger }}
-# TODO: FreeBSD build is broken
-#  build-freebsd:
-#    runs-on: macos-latest
-#    name: FreeBSD LLVM Clang build
-#    steps:
-#      - uses: actions/checkout@v2
-#      - name: Build on FreeBSD
-#        id: build
-#        uses: vmactions/freebsd-vm@v0.0.9
-#        with:
-#          usesh: true
-#          prepare: pkg install -y sdl2 pkgconf
-#          run: |
-#            freebsd-version
-#            make
+
+  build-freebsd:
+    runs-on: ubuntu-latest
+    name: FreeBSD LLVM Clang build
+    strategy:
+      matrix:
+        penger: ["", "PENGER=1"]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build on FreeBSD
+        id: build
+        uses: vmactions/freebsd-vm@v1
+        with:
+          usesh: true
+          prepare: pkg install -y sdl2 pkgconf
+          run: |
+            freebsd-version
+            make ${{ matrix.penger }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
         compiler: [gcc, clang]
         penger: ["", "PENGER=1"]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: install dependencies
         run: |
           sudo apt-get update
@@ -25,7 +25,7 @@ jobs:
       matrix:
         penger: ["", "PENGER=1"]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: install dependencies
         run: brew install sdl2 pkg-config
       - name: build sowon
@@ -39,7 +39,7 @@ jobs:
       matrix:
         penger: ["", "PENGER"]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
         # this runs vcvarsall for us, so we get the MSVC toolchain in PATH.
       - uses: seanmiddleditch/gha-setup-vsdevenv@master
       - name: download sdl2
@@ -59,7 +59,7 @@ jobs:
       matrix:
         penger: ["", "PENGER=1"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Build on FreeBSD
         id: build
         uses: vmactions/freebsd-vm@v1

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 COMMON_CFLAGS=		-Wall -Wextra -std=c99 -pedantic
-CFLAGS+=		`pkg-config --cflags sdl2` $(COMMON_CFLAGS)
+CFLAGS=		`pkg-config --cflags sdl2` $(if $(PENGER),-DPENGER) $(COMMON_CFLAGS)
 COMMON_LIBS=		-lm
 LIBS=			`pkg-config --libs sdl2` $(COMMON_LIBS)
 PREFIX?=		/usr/local
@@ -8,7 +8,7 @@ INSTALL?=		install
 .PHONY: all
 all: Makefile sowon man
 
-sowon: main.c digits.h penger_walk_sheet.h
+sowon: main.c digits.h $(if $(PENGER),penger_walk_sheet.h)
 	$(CC) $(CFLAGS) -o sowon main.c $(LIBS)
 
 digits.h: png2c digits.png

--- a/build_msvc.bat
+++ b/build_msvc.bat
@@ -4,7 +4,12 @@ rem launch this from msvc-enabled console
 set CXXFLAGS=/std:c++17 /O2 /FC /W4 /WX /nologo
 set INCLUDES=/I SDL2\include
 set LIBS=SDL2\lib\x64\SDL2.lib SDL2\lib\x64\SDL2main.lib Shell32.lib
-
+if "%1"=="PENGER" (
+    set CXXFLAGS=%CXXFLAGS% /DPENGER
+)
 cl.exe %CXXFLAGS% /Fepng2c png2c.c /link Shell32.lib -SUBSYSTEM:console
-png2c.exe digits.png > digits.h
+png2c.exe digits.png digits > digits.h
+if "%1"=="PENGER" (
+    png2c.exe penger_walk_sheet.png penger > penger_walk_sheet.h
+)
 cl.exe %CXXFLAGS% %INCLUDES% /Fesowon main.c /link %LIBS% -SUBSYSTEM:windows

--- a/main.c
+++ b/main.c
@@ -5,7 +5,11 @@
 #include <string.h>
 #include <time.h>
 
+#ifdef _WIN32
+#include <SDL.h>
+#else
 #include <SDL2/SDL.h>
+#endif
 
 #include "./digits.h"
 
@@ -118,7 +122,7 @@ void render_penger_at(SDL_Renderer *renderer, SDL_Texture *penger, float time, i
     
     int step = (int)(time*sps)%(60*sps); //step index [0,60*sps-1]
 
-    float progress  = step/(60.0*sps); // [0,1]
+    float progress  = step/(60.0f*sps); // [0,1]
     
     int frame_index = step%2;
 
@@ -134,8 +138,8 @@ void render_penger_at(SDL_Renderer *renderer, SDL_Texture *penger, float time, i
     };
 
     SDL_Rect dst_rect = {
-        floorf((float)penger_walk_width * progress - penger_drawn_width),
-        window_height - (penger_height / PENGER_SCALE),
+        (int) (penger_walk_width * progress - penger_drawn_width),
+        (int) (window_height - (penger_height / PENGER_SCALE)),
         (int) (penger_width / 2) / PENGER_SCALE,
         (int) penger_height / PENGER_SCALE
     };


### PR DESCRIPTION
This PR fixes the Linux and FreeBSD CI and fixes the Windows build.
I also included building with the penger option in the msvc build script and changed the way the penger option is selected as using the CFLAGS didn't work on all platforms.