### PR TITLE
SDL: Upgrade to SDL3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,70 +2,72 @@ name: CI
 on: [push, pull_request]
 
 jobs:
-  build-linux-gcc:
-    runs-on: ubuntu-18.04
+  build-linux:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        compiler: [gcc, clang]
+        penger: ["", "PENGER=1"]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -qq libsdl2-dev
+          sudo apt-get install -qq libsdl3-dev
       - name: build sowon
         run: |
-          make
+          make ${{ matrix.penger }}
         env:
-          CC: gcc
-  build-linux-clang:
-    runs-on: ubuntu-18.04
-    steps:
-      - uses: actions/checkout@v1
-      - name: install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -qq libsdl2-dev
-      - name: build sowon
-        run: |
-          make
-        env:
-          CC: clang
+          CC: ${{ matrix.compiler }}
+
   build-macos:
-    runs-on: macOS-latest
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        penger: ["", "PENGER=1"]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: install dependencies
-        run: brew install sdl2 pkg-config
+        run: brew install sdl3 pkg-config
       - name: build sowon
         run: |
-          make
+          make ${{ matrix.penger }}
         env:
           CC: clang
+
   build-windows-msvc:
-    runs-on: windows-2019
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        penger: ["", "PENGER"]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
         # this runs vcvarsall for us, so we get the MSVC toolchain in PATH.
       - uses: seanmiddleditch/gha-setup-vsdevenv@master
-      - name: download sdl2
+      - name: download sdl3
         run: |
-          curl -fsSL -o SDL2-devel-2.0.12-VC.zip https://www.libsdl.org/release/SDL2-devel-2.0.12-VC.zip
-          tar -xf SDL2-devel-2.0.12-VC.zip
-          mv SDL2-2.0.12 SDL2
+          curl -fsSL -o SDL3-devel-3.2.0-VC.zip https://github.com/libsdl-org/SDL/releases/download/release-3.2.0/SDL3-devel-3.2.0-VC.zip
+          tar -xf SDL3-devel-3.2.0-VC.zip
+          mv SDL3-3.2.0 SDL3
       - name: build sowon
         shell: cmd
         run: |
-          ./build_msvc.bat
-# TODO: FreeBSD build is broken
-#  build-freebsd:
-#    runs-on: macos-latest
-#    name: FreeBSD LLVM Clang build
-#    steps:
-#      - uses: actions/checkout@v2
-#      - name: Build on FreeBSD
-#        id: build
-#        uses: vmactions/freebsd-vm@v0.0.9
-#        with:
-#          usesh: true
-#          prepare: pkg install -y sdl2 pkgconf
-#          run: |
-#            freebsd-version
-#            make
+          build_msvc.bat ${{ matrix.penger }}
+
+  build-freebsd:
+    runs-on: ubuntu-latest
+    name: FreeBSD LLVM Clang build
+    strategy:
+      matrix:
+        penger: ["", "PENGER=1"]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build on FreeBSD
+        id: build
+        uses: vmactions/freebsd-vm@v1
+        with:
+          usesh: true
+          prepare: pkg install -y sdl3 pkgconf
+          run: |
+            freebsd-version
+            make ${{ matrix.penger }}

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ digits.h
 penger_walk_sheet.h
 *.kra
 *~
-SDL2
+SDL3
 *.obj
 *.exe
 .dSYM/

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,14 @@
 COMMON_CFLAGS=		-Wall -Wextra -std=c99 -pedantic
-CFLAGS+=		`pkg-config --cflags sdl2` $(COMMON_CFLAGS)
+CFLAGS+=		`pkg-config --cflags sdl3` $(if $(PENGER),-DPENGER) $(COMMON_CFLAGS)
 COMMON_LIBS=		-lm
-LIBS=			`pkg-config --libs sdl2` $(COMMON_LIBS)
+LIBS=			`pkg-config --libs sdl3` $(COMMON_LIBS)
 PREFIX?=		/usr/local
 INSTALL?=		install
 
 .PHONY: all
 all: Makefile sowon man
 
-sowon: main.c digits.h penger_walk_sheet.h
+sowon: main.c digits.h $(if $(PENGER),penger_walk_sheet.h)
 	$(CC) $(CFLAGS) -o sowon main.c $(LIBS)
 
 digits.h: png2c digits.png

--- a/README.md
+++ b/README.md
@@ -6,18 +6,18 @@
 
 ## Build
 
-Dependencies: [SDL2](https://www.libsdl.org/download-2.0.php)
+Dependencies: [SDL3](https://github.com/libsdl-org/SDL/releases/tag/release-3.2.0)
 
 ### Debian
 ```console
-$ sudo apt-get install libsdl2-dev
+$ sudo apt-get install libsdl3-dev
 $ make
 ```
 
 ### MacOS
 
 ```console
-$ brew install sdl2 pkg-config
+$ brew install sdl3 pkg-config
 $ make
 ```
 
@@ -27,13 +27,13 @@ $ make
 
 - Enter the Visual Studio Command Line Development Environment https://docs.microsoft.com/en-us/cpp/build/building-on-the-command-line
   - Basically just find `vcvarsall.bat` and run `vcvarsall.bat x64` inside of cmd
-- Download [SDL2 VC Development Libraries](https://libsdl.org/release/SDL2-devel-2.0.12-VC.zip) and copy it to `path\to\sowon`
+- Download [SDL3 VC Development Libraries](https://github.com/libsdl-org/SDL/releases/download/release-3.2.0/SDL3-devel-3.2.0-VC.zip) and copy it to `path\to\sowon`
 
 ```console
 > cd path\to\sowon
-> tar -xf SDL2-devel-2.0.12-VC.zip
-> move SDL2-2.0.12 SDL2
-> del SDL2-devel-2.0.12-VC.zip
+> tar -xf SDL3-devel-3.2.0-VC.zip
+> move SDL3-3.2.0 SDL3
+> del SDL3-devel-3.2.0-VC.zip
 > build_msvc
 ```
 
@@ -54,6 +54,7 @@ $ make
 
 | Key | Description |
 | --- | --- |
+| <kbd>ESC</kbd> | Quit |
 | <kbd>SPACE</kbd> | Toggle pause |
 | <kbd>=</kbd> | Zoom in |
 | <kbd>-</kbd> | Zoom out |

--- a/build_msvc.bat
+++ b/build_msvc.bat
@@ -2,9 +2,15 @@
 rem launch this from msvc-enabled console
 
 set CXXFLAGS=/std:c++17 /O2 /FC /W4 /WX /nologo
-set INCLUDES=/I SDL2\include
-set LIBS=SDL2\lib\x64\SDL2.lib SDL2\lib\x64\SDL2main.lib Shell32.lib
+set INCLUDES=/I SDL3\include
+set LIBS=SDL3\lib\x64\SDL3.lib Shell32.lib
 
+if "%1"=="PENGER" (
+    set CXXFLAGS=%CXXFLAGS% /DPENGER
+)
 cl.exe %CXXFLAGS% /Fepng2c png2c.c /link Shell32.lib -SUBSYSTEM:console
-png2c.exe digits.png > digits.h
+png2c.exe digits.png digits > digits.h
+if "%1"=="PENGER" (
+    png2c.exe penger_walk_sheet.png penger > penger_walk_sheet.h
+)
 cl.exe %CXXFLAGS% %INCLUDES% /Fesowon main.c /link %LIBS% -SUBSYSTEM:windows

--- a/main.c
+++ b/main.c
@@ -6,7 +6,9 @@
 #include <time.h>
 #include <math.h>
 
+#define SDL_MAIN_USE_CALLBACKS
 #include <SDL3/SDL.h>
+#include <SDL3/SDL_main.h>
 
 #include "./digits.h"
 
@@ -112,11 +114,11 @@ void render_penger_at(SDL_Renderer *renderer, SDL_Texture *penger, float time, b
     SDL_GetWindowSize(window, &window_width, &window_height);
 
     int sps  = PENGER_STEPS_PER_SECOND;
-    
+
     int step = (int)(time*sps)%(60*sps); //step index [0,60*sps-1]
 
     float progress  = step/(60.0f*sps); // [0,1]
-    
+
     int frame_index = step%2;
 
     float penger_drawn_width = ((float)penger_width / 2) / PENGER_SCALE;
@@ -233,231 +235,276 @@ void frame_end(FpsDeltaTime *fpsdt)
 
 #define TITLE_CAP 256
 
-int main(int argc, char **argv)
+typedef struct {
+    int argc;
+    char **argv;
+    SDL_Window *window;
+    SDL_Renderer *renderer;
+    SDL_Texture *digits;
+    #ifdef PENGER
+    SDL_Texture *penger;
+    #endif
+
+    Mode mode;
+    float displayed_time;
+    bool paused;
+    bool exit_after_countdown;
+
+    size_t wiggle_index;
+    float wiggle_cooldown;
+    float user_scale;
+    char prev_title[TITLE_CAP];
+    FpsDeltaTime fps_dt;
+} AppState;
+
+SDL_AppResult SDL_AppInit(void **appstate, int argc, char **argv)
 {
-    Mode mode = MODE_ASCENDING;
-    float displayed_time = 0.0f;
-    bool paused = false;
-    bool exit_after_countdown = false;
+    AppState *app = SDL_calloc(1, sizeof(AppState));
+    *appstate = app;
+
+    app->argc = argc;
+    app->argv = argv;
+    app->wiggle_cooldown = WIGGLE_DURATION;
+    app->user_scale = 1.0f;
+    app->fps_dt = make_fpsdeltatime(FPS);
 
     for (int i = 1; i < argc; ++i) {
         if (strcmp(argv[i], "-p") == 0) {
-            paused = true;
+            app->paused = true;
         } else if (strcmp(argv[i], "-e") == 0) {
-            exit_after_countdown = true;
+            app->exit_after_countdown = true;
         } else if (strcmp(argv[i], "clock") == 0) {
-            mode = MODE_CLOCK;
+            app->mode = MODE_CLOCK;
         } else {
-            mode = MODE_COUNTDOWN;
-            displayed_time = parse_time(argv[i]);
+            app->mode = MODE_COUNTDOWN;
+            app->displayed_time = parse_time(argv[i]);
         }
     }
 
     secc(SDL_Init(SDL_INIT_VIDEO));
 
-    SDL_Window *window =
+    app->window =
         secp(SDL_CreateWindow(
                  "sowon",
                  TEXT_WIDTH, TEXT_HEIGHT*2,
                  SDL_WINDOW_RESIZABLE));
 
-    SDL_Renderer *renderer = secp(SDL_CreateRenderer(window, NULL));
+    app->renderer = secp(SDL_CreateRenderer(app->window, NULL));
+    // Use VSync
+    SDL_SetRenderVSync(app->renderer, SDL_RENDERER_VSYNC_ADAPTIVE);
 
-    SDL_Texture *digits = load_digits_png_file_as_texture(renderer);
+    app->digits = load_digits_png_file_as_texture(app->renderer);
 
     #ifdef PENGER
-    SDL_Texture *penger = load_penger_png_file_as_texture(renderer);
+    app->penger = load_penger_png_file_as_texture(app->renderer);
     #endif
 
-    secc(SDL_SetTextureColorMod(digits, MAIN_COLOR_R, MAIN_COLOR_G, MAIN_COLOR_B));
+    secc(SDL_SetTextureColorMod(app->digits, MAIN_COLOR_R, MAIN_COLOR_G, MAIN_COLOR_B));
 
-    if (paused) {
-        secc(SDL_SetTextureColorMod(digits, PAUSE_COLOR_R, PAUSE_COLOR_G, PAUSE_COLOR_B));
+    if (app->paused) {
+        secc(SDL_SetTextureColorMod(app->digits, PAUSE_COLOR_R, PAUSE_COLOR_G, PAUSE_COLOR_B));
     } else {
-        secc(SDL_SetTextureColorMod(digits, MAIN_COLOR_R, MAIN_COLOR_G, MAIN_COLOR_B));
+        secc(SDL_SetTextureColorMod(app->digits, MAIN_COLOR_R, MAIN_COLOR_G, MAIN_COLOR_B));
     }
 
-    bool quit = false;
-    size_t wiggle_index = 0;
-    float wiggle_cooldown = WIGGLE_DURATION;
-    float user_scale = 1.0f;
-    char prev_title[TITLE_CAP];
-    FpsDeltaTime fps_dt = make_fpsdeltatime(FPS);
-    while (!quit) {
-        frame_start(&fps_dt);
-        // INPUT BEGIN //////////////////////////////
-        SDL_Event event = {0};
-        while (SDL_PollEvent(&event)) {
-            switch (event.type) {
-            case SDL_EVENT_QUIT: {
-                quit = true;
-            } break;
+    return SDL_APP_CONTINUE;
+}
 
-            case SDL_EVENT_KEY_DOWN: {
-                switch (event.key.key) {
-                case SDLK_ESCAPE: {
-                    quit = true;
-                } break;
-                case SDLK_SPACE: {
-                    paused = !paused;
-                    if (paused) {
-                        secc(SDL_SetTextureColorMod(digits, PAUSE_COLOR_R, PAUSE_COLOR_G, PAUSE_COLOR_B));
-                    } else {
-                        secc(SDL_SetTextureColorMod(digits, MAIN_COLOR_R, MAIN_COLOR_G, MAIN_COLOR_B));
-                    }
-                } break;
+// INPUT BEGIN //////////////////////////////
+SDL_AppResult SDL_AppEvent(void *appstate, SDL_Event *event)
+{
+    AppState* app = (AppState*)appstate;
 
-                case SDLK_KP_PLUS:
-                case SDLK_EQUALS: {
-                    user_scale += SCALE_FACTOR * user_scale;
-                } break;
+    switch (event->type) {
+    case SDL_EVENT_QUIT:
+        return SDL_APP_SUCCESS;
 
-                case SDLK_KP_MINUS:
-                case SDLK_MINUS: {
-                    user_scale -= SCALE_FACTOR * user_scale;
-                } break;
+    case SDL_EVENT_KEY_DOWN: {
+        switch (event->key.key) {
+        case SDLK_ESCAPE:
+            return true;
 
-                case SDLK_KP_0:
-                case SDLK_0: {
-                    user_scale = 1.0f;
-                } break;
-
-                case SDLK_F5: {
-                    displayed_time = 0.0f;
-                    paused = false;
-                    for (int i = 1; i < argc; ++i) {
-                        if (strcmp(argv[i], "-p") == 0) {
-                            paused = true;
-                        } else {
-                            displayed_time = parse_time(argv[i]);
-                        }
-                    }
-                    if (paused) {
-                        secc(SDL_SetTextureColorMod(digits, PAUSE_COLOR_R, PAUSE_COLOR_G, PAUSE_COLOR_B));
-                    } else {
-                        secc(SDL_SetTextureColorMod(digits, MAIN_COLOR_R, MAIN_COLOR_G, MAIN_COLOR_B));
-                    }
-                } break;
-
-                case SDLK_F11: {
-                    SDL_WindowFlags window_flags;
-                    secc(window_flags = SDL_GetWindowFlags(window));
-                    if(window_flags & SDL_WINDOW_FULLSCREEN) {
-                        secc(SDL_SetWindowFullscreen(window, false));
-                    } else {
-                        secc(SDL_SetWindowFullscreen(window, true));
-                    }
-                } break;
-                }
-            } break;
-
-            case SDL_EVENT_MOUSE_WHEEL: {
-                if (SDL_GetModState() & SDL_KMOD_CTRL) {
-                    if (event.wheel.y > 0) {
-                        user_scale += SCALE_FACTOR * user_scale;
-                    } else if (event.wheel.y < 0) {
-                        user_scale -= SCALE_FACTOR * user_scale;
-                    }
-                }
-            } break;
-
-            default: {}
+        case SDLK_SPACE: {
+            app->paused = !app->paused;
+            if (app->paused) {
+                secc(SDL_SetTextureColorMod(app->digits, PAUSE_COLOR_R, PAUSE_COLOR_G, PAUSE_COLOR_B));
+            } else {
+                secc(SDL_SetTextureColorMod(app->digits, MAIN_COLOR_R, MAIN_COLOR_G, MAIN_COLOR_B));
             }
-        }
-        // INPUT END //////////////////////////////
+        } break;
 
-        // RENDER BEGIN //////////////////////////////
-        SDL_SetRenderDrawColor(renderer, BACKGROUND_COLOR_R, BACKGROUND_COLOR_G, BACKGROUND_COLOR_B, 255);
-        SDL_RenderClear(renderer);
-        {
-            const size_t t = (size_t) floorf(fmaxf(displayed_time, 0.0f));
-            // PENGER BEGIN //////////////////////////////
+        case SDLK_KP_PLUS:
+        case SDLK_EQUALS: {
+            app->user_scale += SCALE_FACTOR * app->user_scale;
+        } break;
 
-            #ifdef PENGER
-            render_penger_at(renderer, penger, displayed_time, mode==MODE_COUNTDOWN, window);
-            #endif
+        case SDLK_KP_MINUS:
+        case SDLK_MINUS: {
+            app->user_scale -= SCALE_FACTOR * app->user_scale;
+        } break;
 
-            // PENGER END //////////////////////////////
+        case SDLK_KP_0:
+        case SDLK_0: {
+            app->user_scale = 1.0f;
+        } break;
 
-            // DIGITS BEGIN //////////////////////////////
-            float pen_x, pen_y;
-            float fit_scale = 1.0;
-            initial_pen(window, &pen_x, &pen_y, user_scale, &fit_scale);
-
-
-            // TODO: support amount of hours >99
-            const size_t hours = t / 60 / 60;
-            render_digit_at(renderer, digits, hours / 10,   wiggle_index      % WIGGLE_COUNT, &pen_x, &pen_y, user_scale, fit_scale);
-            render_digit_at(renderer, digits, hours % 10,  (wiggle_index + 1) % WIGGLE_COUNT, &pen_x, &pen_y, user_scale, fit_scale);
-            render_digit_at(renderer, digits, COLON_INDEX,  wiggle_index      % WIGGLE_COUNT, &pen_x, &pen_y, user_scale, fit_scale);
-
-            const size_t minutes = t / 60 % 60;
-            render_digit_at(renderer, digits, minutes / 10, (wiggle_index + 2) % WIGGLE_COUNT, &pen_x, &pen_y, user_scale, fit_scale);
-            render_digit_at(renderer, digits, minutes % 10, (wiggle_index + 3) % WIGGLE_COUNT, &pen_x, &pen_y, user_scale, fit_scale);
-            render_digit_at(renderer, digits, COLON_INDEX,  (wiggle_index + 1) % WIGGLE_COUNT, &pen_x, &pen_y, user_scale, fit_scale);
-
-            const size_t seconds = t % 60;
-            render_digit_at(renderer, digits, seconds / 10, (wiggle_index + 4) % WIGGLE_COUNT, &pen_x, &pen_y, user_scale, fit_scale);
-            render_digit_at(renderer, digits, seconds % 10, (wiggle_index + 5) % WIGGLE_COUNT, &pen_x, &pen_y, user_scale, fit_scale);
-
-            char title[TITLE_CAP];
-            snprintf(title, sizeof(title), "%02zu:%02zu:%02zu - sowon", hours, minutes, seconds);
-            if (strcmp(prev_title, title) != 0) {
-                SDL_SetWindowTitle(window, title);
-            }
-            memcpy(title, prev_title, TITLE_CAP);
-            // DIGITS END //////////////////////////////
-        }
-        SDL_RenderPresent(renderer);
-        // RENDER END //////////////////////////////
-
-        // UPDATE BEGIN //////////////////////////////
-        if (wiggle_cooldown <= 0.0f) {
-            wiggle_index++;
-            wiggle_cooldown = WIGGLE_DURATION;
-        }
-        wiggle_cooldown -= fps_dt.dt;
-
-        if (!paused) {
-            switch (mode) {
-            case MODE_ASCENDING: {
-                displayed_time += fps_dt.dt;
-            } break;
-            case MODE_COUNTDOWN: {
-                if (displayed_time > 1e-6) {
-                    displayed_time -= fps_dt.dt;
+        case SDLK_F5: {
+            app->displayed_time = 0.0f;
+            app->paused = false;
+            for (int i = 1; i < app->argc; ++i) {
+                if (strcmp(app->argv[i], "-p") == 0) {
+                    app->paused = true;
                 } else {
-                    displayed_time = 0.0f;
-                    if (exit_after_countdown) {
-                        SDL_Quit();
-                        return 0;
-                    }
+                    app->displayed_time = parse_time(app->argv[i]);
                 }
-            } break;
-            case MODE_CLOCK: {
-                float displayed_time_prev = displayed_time;
-                time_t t = time(NULL);
-                struct tm *tm = localtime(&t);
-                displayed_time = tm->tm_sec
-                               + tm->tm_min  * 60.0f
-                               + tm->tm_hour * 60.0f * 60.0f;
-                if(displayed_time <= displayed_time_prev){
-                    //same second, keep previous count and add subsecond resolution for penger
-                    if(floorf(displayed_time_prev) == floorf(displayed_time_prev+fps_dt.dt)){ //check for no newsecond shenaningans from dt
-                        displayed_time = displayed_time_prev + fps_dt.dt; 
-                    }else{
-                        displayed_time = displayed_time_prev;
-                    }
-                }
-            } break;
+            }
+            if (app->paused) {
+                secc(SDL_SetTextureColorMod(app->digits, PAUSE_COLOR_R, PAUSE_COLOR_G, PAUSE_COLOR_B));
+            } else {
+                secc(SDL_SetTextureColorMod(app->digits, MAIN_COLOR_R, MAIN_COLOR_G, MAIN_COLOR_B));
+            }
+        } break;
+
+        case SDLK_F11: {
+            SDL_WindowFlags window_flags;
+            secc(window_flags = SDL_GetWindowFlags(app->window));
+            if(window_flags & SDL_WINDOW_FULLSCREEN) {
+                secc(SDL_SetWindowFullscreen(app->window, false));
+            } else {
+                secc(SDL_SetWindowFullscreen(app->window, true));
+            }
+        } break;
+        }
+    } break;
+
+    case SDL_EVENT_MOUSE_WHEEL: {
+        if (SDL_GetModState() & SDL_KMOD_CTRL) {
+            if (event->wheel.y > 0) {
+                app->user_scale += SCALE_FACTOR * app->user_scale;
+            } else if (event->wheel.y < 0) {
+                app->user_scale -= SCALE_FACTOR * app->user_scale;
             }
         }
-        // UPDATE END //////////////////////////////
+    } break;
 
-        frame_end(&fps_dt);
+    default: {}
     }
+    return SDL_APP_CONTINUE;
+}
+// INPUT END //////////////////////////////
+
+SDL_AppResult SDL_AppIterate(void *appstate)
+{
+    AppState* app = (AppState*)appstate;
+    frame_start(&app->fps_dt);
+
+    // RENDER BEGIN //////////////////////////////
+    SDL_SetRenderDrawColor(app->renderer, BACKGROUND_COLOR_R, BACKGROUND_COLOR_G, BACKGROUND_COLOR_B, 255);
+    SDL_RenderClear(app->renderer);
+    {
+        const size_t t = (size_t) floorf(fmaxf(app->displayed_time, 0.0f));
+
+        // PENGER BEGIN //////////////////////////////
+
+        #ifdef PENGER
+        render_penger_at(app->renderer, app->penger, app->displayed_time, app->mode == MODE_COUNTDOWN, app->window);
+        #endif
+
+        // PENGER END //////////////////////////////
+
+        // DIGITS BEGIN //////////////////////////////
+        float pen_x, pen_y;
+        float fit_scale = 1.0;
+        initial_pen(app->window, &pen_x, &pen_y, app->user_scale, &fit_scale);
+
+
+        // TODO: support amount of hours >99
+        const size_t hours = t / 60 / 60;
+        render_digit_at(app->renderer, app->digits, hours / 10,   app->wiggle_index      % WIGGLE_COUNT, &pen_x, &pen_y, app->user_scale, fit_scale);
+        render_digit_at(app->renderer, app->digits, hours % 10,  (app->wiggle_index + 1) % WIGGLE_COUNT, &pen_x, &pen_y, app->user_scale, fit_scale);
+        render_digit_at(app->renderer, app->digits, COLON_INDEX,  app->wiggle_index      % WIGGLE_COUNT, &pen_x, &pen_y, app->user_scale, fit_scale);
+
+        const size_t minutes = t / 60 % 60;
+        render_digit_at(app->renderer, app->digits, minutes / 10, (app->wiggle_index + 2) % WIGGLE_COUNT, &pen_x, &pen_y, app->user_scale, fit_scale);
+        render_digit_at(app->renderer, app->digits, minutes % 10, (app->wiggle_index + 3) % WIGGLE_COUNT, &pen_x, &pen_y, app->user_scale, fit_scale);
+        render_digit_at(app->renderer, app->digits, COLON_INDEX,  (app->wiggle_index + 1) % WIGGLE_COUNT, &pen_x, &pen_y, app->user_scale, fit_scale);
+
+        const size_t seconds = t % 60;
+        render_digit_at(app->renderer, app->digits, seconds / 10, (app->wiggle_index + 4) % WIGGLE_COUNT, &pen_x, &pen_y, app->user_scale, fit_scale);
+        render_digit_at(app->renderer, app->digits, seconds % 10, (app->wiggle_index + 5) % WIGGLE_COUNT, &pen_x, &pen_y, app->user_scale, fit_scale);
+
+        char title[TITLE_CAP];
+        snprintf(title, sizeof(title), "%02zu:%02zu:%02zu - sowon", hours, minutes, seconds);
+        if (strcmp(app->prev_title, title) != 0) {
+            SDL_SetWindowTitle(app->window, title);
+        }
+        memcpy(title, app->prev_title, TITLE_CAP);
+        // DIGITS END //////////////////////////////
+    }
+    SDL_RenderPresent(app->renderer);
+    // RENDER END //////////////////////////////
+
+    // UPDATE BEGIN //////////////////////////////
+    if (app->wiggle_cooldown <= 0.0f) {
+        app->wiggle_index++;
+        app->wiggle_cooldown = WIGGLE_DURATION;
+    }
+    app->wiggle_cooldown -= app->fps_dt.dt;
+
+    if (!app->paused) {
+        switch (app->mode) {
+        case MODE_ASCENDING: {
+            app->displayed_time += app->fps_dt.dt;
+        } break;
+        case MODE_COUNTDOWN: {
+            if (app->displayed_time > 1e-6) {
+                app->displayed_time -= app->fps_dt.dt;
+            } else {
+                app->displayed_time = 0.0f;
+                if (app->exit_after_countdown) {
+                    return SDL_APP_SUCCESS;
+                }
+            }
+        } break;
+        case MODE_CLOCK: {
+            float displayed_time_prev = app->displayed_time;
+            time_t t = time(NULL);
+            struct tm *tm = localtime(&t);
+            app->displayed_time = tm->tm_sec
+                           + tm->tm_min  * 60.0f
+                           + tm->tm_hour * 60.0f * 60.0f;
+            if(app->displayed_time <= displayed_time_prev){
+                //same second, keep previous count and add subsecond resolution for penger
+                if(floorf(displayed_time_prev) == floorf(displayed_time_prev+app->fps_dt.dt)){ //check for no newsecond shenaningans from dt
+                    app->displayed_time = displayed_time_prev + app->fps_dt.dt;
+                }else{
+                    app->displayed_time = displayed_time_prev;
+                }
+            }
+        } break;
+        }
+    }
+    // UPDATE END //////////////////////////////
+
+    frame_end(&app->fps_dt);
+    return SDL_APP_CONTINUE;
+}
+
+void SDL_AppQuit(void *appstate, SDL_AppResult result)
+{
+    (void)result;
+
+    AppState* app = (AppState*)appstate;
+    if (!app)
+        return;
+
+    SDL_DestroyTexture(app->digits);
+    #ifdef PENGER
+    SDL_DestroyTexture(app->penger);
+    #endif
+    SDL_DestroyRenderer(app->renderer);
+    SDL_DestroyWindow(app->window);
+    SDL_free(app);
 
     SDL_Quit();
-
-    return 0;
 }


### PR DESCRIPTION
This pull request moves support from SDL2 to SDL3 (which was released 2 weeks ago as 3.2.0)

This change also includes changes from #37 and #42 as well.

Also sowon was moved to [SDL3 main functions](https://wiki.libsdl.org/SDL3/README/main-functions) from classic main function for compatibility across platforms (including Windows and platforms with less straightforward lifecycle such as Android or WebAssembly)

About gh Actions: Linux and macOS are so very modern so they don't have SDL3 yet, luckily FreeBSD have (and for Windows SDL3 explicitly downloads)