### PR TITLE
Dynamically generate manpage installation paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ SDL2
 *.exe
 .dSYM/
 *.gz
+sowon.6

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ man:
 
 .PHONY: clean
 clean:
-	rm sowon docs/sowon.6.gz png2c
+	rm -f sowon sowon_rgfw docs/sowon.6.gz png2c
 
 .PHONY: install
 install: all man

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ PREFIX?=		/usr/local
 INSTALL?=		install
 
 .PHONY: all
-all: Makefile sowon sowon_rgfw man
+all: Makefile sowon sowon_rgfw
 
 sowon_rgfw: main_rgfw.c digits.h penger_walk_sheet.h
 	$(CC) $(RGFW_CFLAGS) -o sowon_rgfw main_rgfw.c $(RGFW_LIBS)
@@ -31,18 +31,19 @@ penger_walk_sheet.h: png2c penger_walk_sheet.png
 png2c: png2c.c
 	$(CC) $(COMMON_CFLAGS) -o png2c png2c.c -lm
 
-docs/sowon.6.gz: docs/sowon.6
-	gzip -c docs/sowon.6 > docs/sowon.6.gz
-
 .PHONY: man
-man: docs/sowon.6.gz
+man:
+	sed -e "s|%SOWON_SDL2_PATH%|$(DESTDIR)$(PREFIX)/bin/sowon|g" \
+		-e "s|%SOWON_RGFW_PATH%|$(DESTDIR)$(PREFIX)/bin/sowon_rgfw|g" \
+		docs/sowon.template.6 > docs/sowon.6
+	gzip -c docs/sowon.6 > docs/sowon.6.gz
 
 .PHONY: clean
 clean:
 	rm sowon docs/sowon.6.gz png2c
 
 .PHONY: install
-install: all
+install: all man
 	$(INSTALL) -d $(DESTDIR)$(PREFIX)/bin
 	$(INSTALL) -C ./sowon $(DESTDIR)$(PREFIX)/bin
 	$(INSTALL) -C ./sowon_rgfw $(DESTDIR)$(PREFIX)/bin

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ man:
 
 .PHONY: clean
 clean:
-	rm -f sowon sowon_rgfw docs/sowon.6.gz png2c
+	rm -f sowon sowon_rgfw docs/sowon.6 docs/sowon.6.gz png2c
 
 .PHONY: install
 install: all man

--- a/docs/sowon.template.6
+++ b/docs/sowon.template.6
@@ -37,7 +37,8 @@ Restart
 .It F11
 Fullscreen
 .Sh FILES
-.Pa /usr/local/bin/sowon
+.Pa %SOWON_SDL2_PATH%
+.Pa %SOWON_RGFW_PATH%
 .br
 .Sh AUTHOR
 .An Alexey Kutepov aka. rexim


### PR DESCRIPTION
The installation path /usr/local/bin/sowon was previously hardcoded in the manpage, this PR updates the installation process to correctly reference the actual installation paths

Also minor fix to the clean target so that it also deletes sowon_rgfw