### PR TITLE
Add runtime parsing of colors using flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ $ make
 $ ./sowon
 ```
 
+### Fedora 42+
+
+```console
+$ sudo dnf install libXi-devel libXrandr-devel
+$ make
+$ ./sowon
+```
+
 ### MacOS
 
 ```console
@@ -50,7 +58,7 @@ $ ./sowon
 | Key | Description |
 | --- | --- |
 | <kbd>SPACE</kbd> | Toggle pause |
-| <kbd>=</kbd> | Zoom in |
+| <kbd>=</kbd> or <kbd>+</kbd> | Zoom in |
 | <kbd>-</kbd> | Zoom out |
 | <kbd>0</kbd> | Zoom 100% |
 | <kbd>F5</kbd> | Restart |

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,13 @@
+# TODO
+
+## General
+
+
+## QOL
+
+- more sane defaults for config (default is 0 for all colors rn)
+
+### Audio
+- alert sound when countdown mode is enabled and it hits 0
+- option clock ticking noise
+- 

--- a/src/common.c
+++ b/src/common.c
@@ -1,11 +1,14 @@
 #include "digits.h"
 
+
 #ifdef PENGER
 #include "penger_walk_sheet.h"
 #endif
 
 #include <math.h>
 #include <time.h>
+#include <stdio.h>
+#include <string.h>
 
 #define FPS 60
 #define COLON_INDEX 10
@@ -18,15 +21,6 @@
 #define CHARS_COUNT 8
 #define TEXT_WIDTH (CHAR_WIDTH * CHARS_COUNT)
 #define TEXT_HEIGHT (CHAR_HEIGHT)
-#define MAIN_COLOR_R 220
-#define MAIN_COLOR_G 220
-#define MAIN_COLOR_B 220
-#define PAUSE_COLOR_R 220
-#define PAUSE_COLOR_G 120
-#define PAUSE_COLOR_B 120
-#define BACKGROUND_COLOR_R 24
-#define BACKGROUND_COLOR_G 24
-#define BACKGROUND_COLOR_B 24
 #define PENGER_STEPS_PER_SECOND 3
 #define PENGER_SCALE 4
 #define SCALE_FACTOR 0.15f
@@ -81,6 +75,12 @@ typedef struct {
     char prev_title[TITLE_CAP];
 } State;
 
+typedef struct {
+    int red;
+    int green;
+    int blue;
+} Color;
+
 void parse_state_from_args(State *state, int argc, char **argv)
 {
     memset(state, 0, sizeof(*state));
@@ -95,13 +95,70 @@ void parse_state_from_args(State *state, int argc, char **argv)
             state->exit_after_countdown = 1;
         } else if (strcmp(argv[i], "clock") == 0) {
             state->mode = MODE_CLOCK;
-        } else {
+        } else if (strcmp(argv[i], "-t") == 0) {
+	    if (i+1 == argc) {
+		fprintf(stderr, "Missing argument for flag -t!\n");
+		exit(1);
+	    }
             state->mode = MODE_COUNTDOWN;
-            state->displayed_time = parse_time(argv[i]);
+            state->displayed_time = parse_time(argv[i+1]);
         }
     }
+
 }
 
+void parse_hex_color_code(Color *container, char *code) {
+    container->red = -1;
+    container->green = -1;
+    container->blue = -1;
+    if (strlen(code) != 6) {
+	printf("Invalid hexademical string enter for color, defaulting to 0!");
+	return;
+    }
+    int cur = 0;
+    char *tmp = malloc(3 * sizeof(char));
+    for (int i = 0; i < 6; i++) {
+	if (i % 2 == 0) {
+	    strncpy(tmp, code+i, 2);
+    	    tmp[2] = '\0';
+    	    cur = (int)strtol(tmp, NULL, 16);
+
+    	    if (container->red == -1) { container->red = cur; }
+    	    else if (container->green == -1) { container->green = cur; }
+    	    else if (container->blue == -1) { container->blue = cur; }
+	}
+    }
+    free(tmp);
+}
+
+void parse_colors_from_args(Color *background_color, Color *pause_color, Color *main_color, int argc, char **argv) {
+    memset(background_color, 0, sizeof(*background_color)); 
+    memset(pause_color, 0, sizeof(*pause_color));
+    memset(main_color, 0, sizeof(*main_color));
+
+    for (int i = 1; i < argc; ++i) {
+        if (strcmp(argv[i], "--background-color") == 0) {
+	    if (i+1 == argc) {
+		fprintf(stderr,"No background color supplied, but flag used!");
+		exit(1);
+	    }
+            parse_hex_color_code(background_color, argv[i+1]);
+	} else if (strcmp(argv[i], "--pause-color") == 0) {
+	    if (i+1 == argc) {
+		fprintf(stderr,"No pause color supplied, but flag used!");
+		exit(1);
+	    }
+            parse_hex_color_code(pause_color, argv[i+1]);
+	} else if (strcmp(argv[i], "--main-color") == 0) {
+	    if (i+1 == argc) {
+		fprintf(stderr,"No main color supplied, but flag used!");
+		exit(1);
+	    }
+            parse_hex_color_code(main_color, argv[i+1]);
+	} 
+    }
+
+}
 void state_update(State *state, float dt)
 {
     if (state->wiggle_cooldown <= 0.0f) {

--- a/src/common.c
+++ b/src/common.c
@@ -112,7 +112,7 @@ void parse_hex_color_code(Color *container, char *code) {
     container->green = -1;
     container->blue = -1;
     if (strlen(code) != 6) {
-	printf("Invalid hexademical string enter for color, defaulting to 0!");
+	printf("WARNING: Invalid hexademical string enter for color, defaulting to 0!\n");
 	return;
     }
     int cur = 0;
@@ -139,19 +139,19 @@ void parse_colors_from_args(Color *background_color, Color *pause_color, Color *
     for (int i = 1; i < argc; ++i) {
         if (strcmp(argv[i], "--background-color") == 0) {
 	    if (i+1 == argc) {
-		fprintf(stderr,"No background color supplied, but flag used!");
+		fprintf(stderr,"ERROR: No background color supplied, but flag used!\n");
 		exit(1);
 	    }
             parse_hex_color_code(background_color, argv[i+1]);
 	} else if (strcmp(argv[i], "--pause-color") == 0) {
 	    if (i+1 == argc) {
-		fprintf(stderr,"No pause color supplied, but flag used!");
+		fprintf(stderr,"ERROR: No pause color supplied, but flag used!\n");
 		exit(1);
 	    }
             parse_hex_color_code(pause_color, argv[i+1]);
 	} else if (strcmp(argv[i], "--main-color") == 0) {
 	    if (i+1 == argc) {
-		fprintf(stderr,"No main color supplied, but flag used!");
+		fprintf(stderr,"ERROR: No main color supplied, but flag used!\n");
 		exit(1);
 	    }
             parse_hex_color_code(main_color, argv[i+1]);

--- a/src/main.c
+++ b/src/main.c
@@ -269,8 +269,12 @@ void render_penger_at(GLint penger_tex_unit, int window_width, int window_height
 int main(int argc, char **argv)
 {
     State state = {0};
+    Color background_color = {0}; 
+    Color pause_color      = {0}; 
+    Color main_color       = {0}; 
 
     parse_state_from_args(&state, argc, argv);
+    parse_colors_from_args(&background_color, &pause_color, &main_color, argc, argv);
 
     RGFW_glHints *hints = RGFW_getGlobalHints_OpenGL();
     hints->profile = RGFW_glCore;
@@ -311,11 +315,9 @@ int main(int argc, char **argv)
     GLint penger_tex_unit = load_image_data_as_gl_texture(penger_data, penger_width, penger_height);
     #endif
 
-    set_texture_color_mod(MAIN_COLOR_R/255.0f, MAIN_COLOR_G/255.0f, MAIN_COLOR_B/255.0f);
+    set_texture_color_mod(main_color.red/255.0f, main_color.green/255.0f, main_color.blue/255.0f);
     if (state.paused) {
-        set_texture_color_mod(PAUSE_COLOR_R/255.0f, PAUSE_COLOR_G/255.0f, PAUSE_COLOR_B/255.0f);
-    } else {
-        set_texture_color_mod(MAIN_COLOR_R/255.0f, MAIN_COLOR_G/255.0f, MAIN_COLOR_B/255.0f);
+        set_texture_color_mod(pause_color.red/255.0f, pause_color.green/255.0f, pause_color.blue/255.0f);
     }
 
     GLuint vao;
@@ -341,9 +343,9 @@ int main(int argc, char **argv)
                 case RGFW_space: {
                     state.paused = !state.paused;
                     if (state.paused) {
-                        set_texture_color_mod(PAUSE_COLOR_R/255.0f, PAUSE_COLOR_G/255.0f, PAUSE_COLOR_B/255.0f);
+			set_texture_color_mod(pause_color.red/255.0f, pause_color.green/255.0f, pause_color.blue/255.0f);
                     } else {
-                        set_texture_color_mod(MAIN_COLOR_R/255.0f, MAIN_COLOR_G/255.0f, MAIN_COLOR_B/255.0f);
+			set_texture_color_mod(main_color.red/255.0f, main_color.green/255.0f, main_color.blue/255.0f);
                     }
                 } break;
 
@@ -368,9 +370,9 @@ int main(int argc, char **argv)
                 case RGFW_F5: {
                     parse_state_from_args(&state, argc, argv);
                     if (state.paused) {
-                        set_texture_color_mod(PAUSE_COLOR_R/255.0f, PAUSE_COLOR_G/255.0f, PAUSE_COLOR_B/255.0f);
+			set_texture_color_mod(pause_color.red/255.0f, pause_color.green/255.0f, pause_color.blue/255.0f);
                     } else {
-                        set_texture_color_mod(MAIN_COLOR_R/255.0f, MAIN_COLOR_G/255.0f, MAIN_COLOR_B/255.0f);
+			set_texture_color_mod(main_color.red/255.0f, main_color.green/255.0f, main_color.blue/255.0f);
                     }
                 } break;
 
@@ -398,7 +400,7 @@ int main(int argc, char **argv)
         // INPUT END //////////////////////////////
 
         // RENDER BEGIN //////////////////////////////
-        glClearColor(BACKGROUND_COLOR_R/255.0f, BACKGROUND_COLOR_G/255.0f, BACKGROUND_COLOR_B/255.0f, 1);
+        glClearColor(background_color.red/255.0f, background_color.green/255.0f, background_color.blue/255.0f, 1);
         glClear(GL_COLOR_BUFFER_BIT);
 
         {


### PR DESCRIPTION
Previously, the background, main, and pause colors were set using **three macros each** in `src/common.c`
Now, they are saved in **one struct per color** under `src/main.c`, meaning they can be set at run-time.
Usage:

`sowon --background-color AABBCC --pause-color CCBBAA --main-color 696969`

**The order does not matter, lower-case and upper-case are supported.**
If no valid hex string can be formed from the input, it defaults to black with a warning.
If the color argument is missing, it exits with an error.

This makes it easier to adjust the colors to a certain theme without having to recompile (for example maybe a halloween stream or similar, you might make the colors orange and black) or for other streamers who want to use colors other than the defaults without having to recompile